### PR TITLE
Fix missing shapes in compound shapes

### DIFF
--- a/src/main/java/dev/gigaherz/jsonthings/things/shapes/CombinedShape.java
+++ b/src/main/java/dev/gigaherz/jsonthings/things/shapes/CombinedShape.java
@@ -67,7 +67,7 @@ public class CombinedShape implements IShapeProvider
     {
         return boxes.stream()
                 .map(shape -> shape.getShape(state, facing))
-                .reduce(Optional.empty(), (a, b) -> a.map(aa -> b.map(bb -> Shapes.joinUnoptimized(aa, bb, operator))).orElse(b))
+                .reduce(Optional.empty(), (a, b) -> a.map(aa -> b.map(bb -> Shapes.joinUnoptimized(aa, bb, operator)).or(() -> a)).orElse(b))
                 .map(VoxelShape::optimize);
     }
 


### PR DESCRIPTION
When a compound shape has multiple shapes, some shapes were skipped when a conditional shapes condition is false. This occurred in `reduce` when `a` was non-empty and `b` was empty. The result was that any missing shape removed any shapes before it.